### PR TITLE
Update README.md huggingface-cli is now installed with huggingface-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Using `huggingface-cli` to download the models:
 
 ```shell
 cd $ProjectRootDir
-pip install huggingface-cli
+pip install huggingface-hub
 huggingface-cli download fudan-generative-ai/hallo3 --local-dir ./pretrained_models
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Using `huggingface-cli` to download the models:
 
 ```shell
 cd $ProjectRootDir
-pip install huggingface-hub
+pip install "huggingface_hub[cli]"
 huggingface-cli download fudan-generative-ai/hallo3 --local-dir ./pretrained_models
 ```
 


### PR DESCRIPTION
`pip install huggingface-cli`
throws error
`ERROR: Could not find a version that satisfies the requirement huggingface-cli (from versions: none)`
huggingface-cli is now installed with huggingface-hub. see: https://huggingface.co/docs/huggingface_hub/main/en/guides/cli